### PR TITLE
[bug] Fix FileNotFound error on SFTP backend

### DIFF
--- a/src/repo2.py
+++ b/src/repo2.py
@@ -315,6 +315,10 @@ class Repo(object):
     def init(self, password):
         self.logger.debug(f"Repo.init()")
 
+        self.backend.makedirs("keys")
+        self.backend.makedirs("snapshots")
+        self.backend.makedirs("chunks")
+
         salt, master, sha = os.urandom(16), os.urandom(32), os.urandom(32)
         key = generate_key(salt, password)
         self.backend.write("keys/key-salt", salt)


### PR DESCRIPTION
https://github.com/bimbashrestha/BlobBackup/issues/9

The old data format handled the creation of directories
for SFTP and non-object storages automatically. I forgot
to port the functionality over to the new format.